### PR TITLE
Enable the gitx binary in the CLI

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,19 @@
 # Examples
 #
 #   include gitx
-class gitx {
+class gitx (
+  $enable_cli = true
+) {
+
+  if $enable_cli {
+    file { "${boxen::config::bindir}/gitx":
+      ensure  => link,
+      target  => '/Applications/GitX.app/Contents/Resources/gitx',
+      mode    => '0755',
+      require => Package['GitX'],
+    }
+  }
+
   package { 'GitX':
     source   => 'http://frim.frim.nl/GitXStable.app.zip',
     provider => 'compressed_app'


### PR DESCRIPTION
Previously, the gitx module installed the gitx package only. Gitx
ships with a binary that can be symlinked into /usr/local/bin to
enable opening gitx from the command line.  Usually, this involves
enabling the feature in the app itself, but this commit allows the
module to enable the functionality by symlinking the binary into
$boxen::config::bindir.
