### PR TITLE
GitX-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ Install [GitX](http://gitx.frim.nl), a Mac OS X GUI front-end for Git.
 include gitx
 ```
 
-Or use [GitX (L)](http://gitx.laullon.com/) instead:
+Or use [GitX (L)](http://gitx.laullon.com/):
 
 ```puppet
 include gitx::l
+```
+
+Or use [GitX-dev](http://rowanj.github.com/gitx/):
+
+```puppet
+include gitx::dev
 ```
 
 ## Required Puppet Modules

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -1,0 +1,7 @@
+# GitX-dev by rowanj. Usage:
+#	include gitx::dev
+class gitx::dev inherits gitx {
+  Package['GitX'] {
+    source => 'http://cloud.github.com/downloads/rowanj/gitx/GitX-dev-57.zip',
+  }
+}

--- a/spec/classes/gitx_spec.rb
+++ b/spec/classes/gitx_spec.rb
@@ -16,3 +16,11 @@ describe 'gitx::l' do
     })
   end
 end
+
+describe 'gitx::dev' do
+  it do
+    should contain_package('GitX').with({
+      :source   => 'http://cloud.github.com/downloads/rowanj/gitx/GitX-dev-57.zip',
+    })
+  end
+end


### PR DESCRIPTION
Added rowanj's GitX-dev http://rowanj.github.com/gitx/.

GitX-dev is a fork (variant) of GitX, a long-defunct GUI for the git version-control system. It has been maintained and enhanced with productivity and friendliness oriented changes, with effort focused on making a first-class, maintainable tool for today's active developers.
